### PR TITLE
update assembly info

### DIFF
--- a/PapeTracker/PapeTracker.csproj
+++ b/PapeTracker/PapeTracker.csproj
@@ -56,6 +56,9 @@
   <PropertyGroup>
     <ApplicationIcon>app.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>PapeTracker.App</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -190,7 +193,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-	<Resource Include="app.ico" />
+    <Resource Include="app.ico" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\VerticalBarWhite.png" />

--- a/PapeTracker/Properties/AssemblyInfo.cs
+++ b/PapeTracker/Properties/AssemblyInfo.cs
@@ -7,12 +7,13 @@ using System.Windows;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
+[assembly: Guid("A82F1463-16D1-4E42-BFB2-D11A9F744A54")]
 [assembly: AssemblyTitle("PapeTracker")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("An item tracker for Paper Mario 64 Randomizers.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PapeTracker")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
I created a test release, and I'm able to download PaperTracker on Win11.
https://github.com/shookieTea/PapeTracker/releases/tag/v0.2.3

The assembly was missing a GUID and description. I suspect the issue is the former, but adding the latter can't hurt.
@mukomo if you could verify on your end, let me know :)